### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+#GitHub Linguist overrides for language
+*.asm		linguist-language=Assembly
+*.inc		linguist-language=Assembly


### PR DESCRIPTION
.gitattributes file to eliminate erroneous GitHub language detection.